### PR TITLE
Mark as end-of-life

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "end-of-life": "Discontinued: https://support.toggl.com/en/articles/2410832-toggl-track-desktop-app-for-linux"
+}


### PR DESCRIPTION
This app will stop working on 1st March:

> Toggl Track will no longer be available on Linux by March 1, 2023.
>
> Earlier this year, we launched v9 of the Toggl Track API and announced
> that we would be phasing out v8 within the next six months. The
> existing Linux desktop app, which runs on v8, will no longer function
> once v8 has been fully deprecated.

https://support.toggl.com/en/articles/2410832-toggl-track-desktop-app-for-linux

Fixes https://github.com/flathub/com.toggl.TogglDesktop/issues/9
