### PR TITLE
Toggl fixes 2

### DIFF
--- a/0001-Remove-SSL23-support-from-third_party-Poco-Crypto.patch
+++ b/0001-Remove-SSL23-support-from-third_party-Poco-Crypto.patch
@@ -1,0 +1,34 @@
+From caccc7181611cc9451841ed1317f90aee82ae3ea Mon Sep 17 00:00:00 2001
+From: Newbyte <newbie13xd@gmail.com>
+Date: Sat, 15 Apr 2023 13:04:30 +0200
+Subject: [PATCH] Remove SSL23 support from third_party/Poco/Crypto
+
+Backport of https://github.com/pocoproject/poco/commit/46ef044d7be6cf94ea6557abc81bbedba796184e
+---
+ third_party/poco/Crypto/src/RSACipherImpl.cpp | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/third_party/poco/Crypto/src/RSACipherImpl.cpp b/third_party/poco/Crypto/src/RSACipherImpl.cpp
+index 5c2e493ed..5c61789e3 100755
+--- a/third_party/poco/Crypto/src/RSACipherImpl.cpp
++++ b/third_party/poco/Crypto/src/RSACipherImpl.cpp
+@@ -50,8 +50,6 @@ namespace
+ 			return RSA_PKCS1_PADDING;
+ 		case RSA_PADDING_PKCS1_OAEP:
+ 			return RSA_PKCS1_OAEP_PADDING;
+-		case RSA_PADDING_SSLV23:
+-			return RSA_SSLV23_PADDING;
+ 		case RSA_PADDING_NONE:
+ 			return RSA_NO_PADDING;
+ 		default:
+@@ -116,7 +114,6 @@ namespace
+ 		switch (_paddingMode)
+ 		{
+ 		case RSA_PADDING_PKCS1:
+-		case RSA_PADDING_SSLV23:
+ 			size -= 11;
+ 			break;
+ 		case RSA_PADDING_PKCS1_OAEP:
+-- 
+2.39.2
+

--- a/com.toggl.TogglDesktop.json
+++ b/com.toggl.TogglDesktop.json
@@ -1,7 +1,7 @@
 {
     "id": "com.toggl.TogglDesktop",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.15-21.08",
+    "runtime-version": "5.15-22.08",
     "sdk": "org.kde.Sdk",
     "rename-icon": "toggldesktop",
     "command": "TogglDesktop.sh",

--- a/com.toggl.TogglDesktop.json
+++ b/com.toggl.TogglDesktop.json
@@ -47,6 +47,10 @@
                     "type": "git",
                     "url": "http://github.com/toggl-open-source/toggldesktop",
                     "tag": "v7.5.324"
+                },
+                {
+                    "type": "patch",
+                    "path": "0001-Remove-SSL23-support-from-third_party-Poco-Crypto.patch"
                 }
             ]
         }

--- a/com.toggl.TogglDesktop.json
+++ b/com.toggl.TogglDesktop.json
@@ -35,9 +35,9 @@
             "name": "libXmu",
             "sources": [
                 {
-                    "type": "git",
-                    "url": "git://anongit.freedesktop.org/git/xorg/lib/libXmu",
-                    "tag": "libXmu-1.1.3"
+                    "type": "archive",
+                    "url": "https://xorg.freedesktop.org/releases/individual/lib/libXmu-1.1.3.tar.bz2",
+                    "sha256": "9c343225e7c3dc0904f2122b562278da5fed639b1b5e880d25111561bac5b731"
                 }
             ]
         },

--- a/com.toggl.TogglDesktop.json
+++ b/com.toggl.TogglDesktop.json
@@ -19,15 +19,6 @@
         "--talk-name=org.freedesktop.portal.Fcitx",
         "--talk-name=org.freedesktop.ScreenSaver",
         "--talk-name=org.gnome.Mutter.IdleMonitor",
-        "--own-name=org.kde.StatusNotifierItem-1-1",
-        "--own-name=org.kde.StatusNotifierItem-2-1",
-        "--own-name=org.kde.StatusNotifierItem-3-1",
-        "--own-name=org.kde.StatusNotifierItem-4-1",
-        "--own-name=org.kde.StatusNotifierItem-5-1",
-        "--own-name=org.kde.StatusNotifierItem-6-1",
-        "--own-name=org.kde.StatusNotifierItem-7-1",
-        "--own-name=org.kde.StatusNotifierItem-8-1",
-        "--own-name=org.kde.StatusNotifierItem-9-1",
         "--system-talk-name=org.freedesktop.login1"
     ],
     "modules": [

--- a/com.toggl.TogglDesktop.json
+++ b/com.toggl.TogglDesktop.json
@@ -45,7 +45,7 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "http://github.com/toggl-open-source/toggldesktop",
+                    "url": "https://github.com/toggl-open-source/toggldesktop",
                     "tag": "v7.5.324"
                 },
                 {

--- a/com.toggl.TogglDesktop.json
+++ b/com.toggl.TogglDesktop.json
@@ -46,7 +46,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/toggl-open-source/toggldesktop",
-                    "tag": "v7.5.324"
+                    "tag": "v7.5.324",
+                    "commit": "43e9272320e7d9cd147420237854846876073d14"
                 },
                 {
                     "type": "patch",


### PR DESCRIPTION
https://github.com/flathub/com.toggl.TogglDesktop/pull/11 somehow doesn't respond to my pushes any more after an erroneous rebase, so here goes another PR.

---

The app somehow still works despite that it should be dead by now, so I decided to upgrade the SDK and fix the build and warnings and errors and all that.

If nothing else, it unblocks https://github.com/flathub/com.toggl.TogglDesktop/pull/10.